### PR TITLE
Count fire-time per spark, not per-fire-event

### DIFF
--- a/src/components/bottom-bar.test.tsx
+++ b/src/components/bottom-bar.test.tsx
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { createStores } from "../models/stores";
 import { Provider } from "mobx-react";
 import { BottomBar } from "./bottom-bar";
-import { Vector2 } from "three";
 import { act } from "react-dom/test-utils";
 
 describe("BottomBar component", () => {

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -47,6 +47,7 @@ export class Cell {
   public isFireLine = false;
   public isFireLineUnderConstruction = false;
   public helitackDropCount = 0;
+  public fireIdx: number | null = null;
 
   constructor(props: CellOptions) {
     Object.assign(this, props);

--- a/src/models/engine/fire-engine.test.ts
+++ b/src/models/engine/fire-engine.test.ts
@@ -72,9 +72,13 @@ describe("FireEngine", () => {
   it("should stop low intensity fire after 5 days (or earlier but it's random)", () => {
     const engine = new FireEngine(generateCells(), wind, config);
     engine.setSparks(sparks);
-    expect(engine.endOfLowIntensityFire).toBe(false);
+    engine.fires.forEach(fire => {
+      expect(fire.endOfLowIntensityFire).toBe(false);
+    });
     engine.updateFire(1440 * 5); // 5 days in minutes
-    expect(engine.endOfLowIntensityFire).toBe(true);
+    engine.fires.forEach(fire => {
+      expect(fire.endOfLowIntensityFire).toBe(true);
+    });
   });
 
   it("should detect when nothing is burning anymore", () => {


### PR DESCRIPTION
[[PT-185422870]](https://github.com/concord-consortium/forestfire/commit/98545167ca6c5f6435f6094f04705f3367753d1f)

Fire Engine has logic that makes low-intensity fires burn out after a few days. That didn't work too well in this sim variant where the user can keep adding sparks - these new sparks will almost immediately die.

So, the logic is updated to count fire time per spark / fire, not per fire event.