### PR TITLE
feat: speed up time in regrowth phase, add new timestep [PT-185424123]

### DIFF
--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -1,10 +1,8 @@
 
 import { BottomBar } from "../support/elements/BottomBar";
-import { ModelInfo } from "../support/elements/ModelInfo";
 
 context("Forest Fire Smoke Test", () => {
   const bottomBar = new BottomBar();
-  const modelInfo = new ModelInfo();
 
   beforeEach(() => {
     cy.visit("/");
@@ -17,18 +15,15 @@ context("Forest Fire Smoke Test", () => {
       bottomBar.getSparkButton().click({ force: true });
       cy.get(".app--mainContent--__forestfire-v1__ canvas").click(800, 600, { force: true });
       bottomBar.getStartButton().should("contain", "Start");
-      modelInfo.getModelTimeProgress().should("contain", "0 days");
-      modelInfo.getModelTimeProgress().should("contain", "0 hours");
 
       bottomBar.getStartButton().click({ force: true });
       cy.wait(3000);
       bottomBar.getStartButton().should("contain", "Pause");
-      modelInfo.getModelTimeProgress().should("not.contain", "0 hours");
     });
+
     it("restarts mode", () => {
       bottomBar.getRestartButton().click({ force: true });
       bottomBar.getStartButton().should("contain", "Start");
-      modelInfo.getModelTimeProgress().should("contain", "0 hours");
     });
   });
 });

--- a/cypress/support/elements/ModelInfo.js
+++ b/cypress/support/elements/ModelInfo.js
@@ -1,5 +1,0 @@
-export class ModelInfo {
-  getModelTimeProgress() {
-    return cy.get(".app--timeDisplay--__forestfire-v1__");
-  }
-}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -28,7 +28,7 @@ export const AppComponent = observer(function WrappedComponent() {
 
   const config = simulation.config;
   const timeInDays = Math.floor(simulation.timeInDays);
-  const timeHours = Math.floor(simulation.timeInHours);
+  const timeHours = Math.floor((simulation.time % 1440) / 60);
   const timeInYears = Math.floor(simulation.timeInYears);
   const showModelScale = config.showModelDimensions;
   return (

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -27,9 +27,9 @@ export const AppComponent = observer(function WrappedComponent() {
   useCustomCursor();
 
   const config = simulation.config;
-  // Convert time from minutes to days.
-  const timeInDays = Math.floor(simulation.time / 1440);
-  const timeHours = Math.floor((simulation.time % 1440) / 60);
+  const timeInDays = Math.floor(simulation.timeInDays);
+  const timeHours = Math.floor(simulation.timeInHours);
+  const timeInYears = Math.floor(simulation.timeInYears);
   const showModelScale = config.showModelDimensions;
   return (
     <div className={css.app}>
@@ -41,7 +41,18 @@ export const AppComponent = observer(function WrappedComponent() {
         </div>
       }
       <div className={css.timeDisplay}>
-        {timeInDays} {timeInDays === 1 ? "day" : "days"} and <br /> {timeHours} {timeHours === 1 ? "hour" : "hours"}
+        {
+          simulation.isFireEventActive &&
+          <>
+            {timeInDays} {timeInDays === 1 ? "day" : "days"} and {timeHours} {timeHours === 1 ? "hour" : "hours"}
+          </>
+        }
+        {
+          !simulation.isFireEventActive &&
+          <>
+            {timeInYears} years
+          </>
+        }
       </div>
       <div className={`${css.mainContent} ${ui.showChart && css.shrink}`}>
         <SimulationInfo />

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -58,8 +58,11 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
   };
 
   const sparkBtnDisabled = !simulation.isFireEventActive || !simulation.canAddSpark || ui.interaction === Interaction.PlaceSpark;
-  // User cannot start the sim until he adds at least one spark during the fire event setup.
-  const startButtonDisabled = !simulation.ready || (simulation.isFireEventSetupActive && simulation.sparks.length === 0);
+  const startButtonDisabled =
+    !simulation.ready ||
+    // User cannot start the sim until he adds at least one spark during the fire event setup.
+    (simulation.isFireEventSetupActive && simulation.sparks.length === 0) ||
+    simulation.simulationEnded;
 
   const FireEventIcon = () => (
     <div className={css.fireEventIcon}>

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,9 +30,11 @@ export interface ISimulationConfig {
   sparks: number[][];
   // Number of available sparks.
   maxSparks: number;
-  maxTimeStep: number; // minutes
-  // One day in model should last X seconds in real world.
-  modelDayInSeconds: number;
+  fireEngineMaxTimeStep: number; // minutes
+  // This variable defines fire event time step. One day in model should last X seconds in real world.
+  fireEventDayInSeconds: number;
+  // This variable defines regrowth phase time step. One year in model should last X seconds in real world.
+  regrowthYearInSeconds: number;
   windSpeed: number; // mph
   windDirection: number; // degrees, 0 is northern wind
   neighborsDist: number;
@@ -104,8 +106,9 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   zoneIndex: undefined,
   sparks: [],
   maxSparks: 10,
-  maxTimeStep: 180, // minutes
-  modelDayInSeconds: 8, // one day in model should last X seconds in real world
+  fireEngineMaxTimeStep: 180, // minutes
+  fireEventDayInSeconds: 8, // one day in model should last X seconds in real world
+  regrowthYearInSeconds: 60 / 400, // 400 years should last 60 seconds. 1 year should last 0.15 seconds.
   windSpeed: 0, // mph
   windDirection: 0, // degrees, northern wind
   // Note that 0.5 helps to create a nicer, more round shape of neighbours set for a given cell

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,8 @@ export interface ISimulationConfig {
   fireEventDayInSeconds: number;
   // This variable defines regrowth phase time step. One year in model should last X seconds in real world.
   regrowthYearInSeconds: number;
+  // Stop model when year reaches this value.
+  simulationEndYear: number;
   windSpeed: number; // mph
   windDirection: number; // degrees, 0 is northern wind
   neighborsDist: number;
@@ -109,6 +111,7 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   fireEngineMaxTimeStep: 180, // minutes
   fireEventDayInSeconds: 8, // one day in model should last X seconds in real world
   regrowthYearInSeconds: 60 / 400, // 400 years should last 60 seconds. 1 year should last 0.15 seconds.
+  simulationEndYear: 400,
   windSpeed: 0, // mph
   windDirection: 0, // degrees, northern wind
   // Note that 0.5 helps to create a nicer, more round shape of neighbours set for a given cell

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -100,6 +100,10 @@ export class SimulationModel {
     return this.time / 525600; // 1440 * 365 minutes in a year, assuming that year has 365 days
   }
 
+  @computed public get simulationEnded() {
+    return this.timeInYears >= this.config.simulationEndYear;
+  }
+
   @computed public get canAddSpark() {
     return this.remainingSparks > 0;
   }
@@ -311,6 +315,10 @@ export class SimulationModel {
       this.updateCellsStateFlag();
 
       this.changeWindIfNecessary();
+    }
+
+    if (!this.isFireEventActive && this.timeInYears >= 400) {
+      this.stop();
     }
   }
 

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -96,6 +96,10 @@ export class SimulationModel {
     return this.time / 1440;
   }
 
+  @computed public get timeInYears() {
+    return this.time / 525600; // 1440 * 365 minutes in a year, assuming that year has 365 days
+  }
+
   @computed public get canAddSpark() {
     return this.remainingSparks > 0;
   }
@@ -269,8 +273,10 @@ export class SimulationModel {
     }
     let timeStep;
     if (realTimeDiffInMinutes) {
-      // One day in model time (86400 seconds) should last X seconds in real time.
-      const ratio = 86400 / this.config.modelDayInSeconds;
+      // One day in model time (86400 seconds) should last X seconds in real time when fire event is active. When the
+      // regrowth phase is active, one year in model time (31536000 seconds) should last X seconds in real time.
+      const ratio = this.isFireEventActive ?
+        (86400 / this.config.fireEventDayInSeconds) : (86400 * 365 / this.config.regrowthYearInSeconds);
       // Optimal time step assumes we have stable 60 FPS:
       // realTime = 1000ms / 60 = 16.666ms
       // timeStepInMs = ratio * realTime
@@ -278,10 +284,14 @@ export class SimulationModel {
       // Below, these calculations are just simplified (1000 / 60 / 1000 / 60 = 0.000277):
       const optimalTimeStep = ratio * 0.000277;
       // Final time step should be limited by:
-      // - maxTimeStep that model can handle
+      // - fireEngineMaxTimeStep that Fire Engine can handle
       // - reasonable multiplication of the "optimal time step" so user doesn't see significant jumps in the simulation
       //   when one tick takes much longer time (e.g. when cell properties are recalculated after adding fire line)
-      timeStep = Math.min(this.config.maxTimeStep, optimalTimeStep * 4, ratio * realTimeDiffInMinutes);
+      timeStep = Math.min(
+        this.isFireEventActive ? this.config.fireEngineMaxTimeStep : Infinity, // regrowth phase has no limits on time step
+        optimalTimeStep * 4,
+        ratio * realTimeDiffInMinutes
+      );
     } else {
       // We don't know performance yet, so simply increase time by some safe value and wait for the next tick.
       timeStep = 1;


### PR DESCRIPTION
This PR greatly speeds up the simulation when there's no fire. The project team required that 400 years should take 60 seconds in the real world. Also, it stops the model automatically after 400 years.