### PR TITLE
Add timeline widget and time progress

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -7,6 +7,7 @@
   height: 100%;
   flex-direction: column;
   background-color: #c8c8c8;
+  color: $textColor;
 }
 
 .mainContent{
@@ -72,4 +73,13 @@
   width: 100%;
   position: fixed;
   bottom: 0;
+}
+
+.timeline {
+  width: 100%;
+  position: fixed;
+  bottom: $bottomBarHeight + 21px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -45,28 +45,9 @@
   top: 10px;
   left: 120px;
   color: $controlText;
-  font-family: Lato;
+  font-family: $lato;
   font-size: 12px;
   font-weight: bold;
-}
-
-.timeDisplay{
-  width: 82px;
-  height: 34px;
-  position: fixed;
-  top: $topBarHeight + 10px;
-  left: 10px;
-  background: white;
-  border-radius: 4px;
-  border: solid 1px $controlGray;
-  text-align: center;
-  color: $controlText;
-  z-index: 2;
-  font-family: Lato;
-  font-size: 12px;
-  font-weight: bold;
-  padding: 4px;
-  padding-top: 8px;
 }
 
 .bottomBar {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -28,9 +28,6 @@ export const AppComponent = observer(function WrappedComponent() {
   useCustomCursor();
 
   const config = simulation.config;
-  const timeInDays = Math.floor(simulation.timeInDays);
-  const timeHours = Math.floor((simulation.time % 1440) / 60);
-  const timeInYears = Math.floor(simulation.timeInYears);
   const showModelScale = config.showModelDimensions;
   return (
     <div className={css.app}>
@@ -41,20 +38,6 @@ export const AppComponent = observer(function WrappedComponent() {
           <div>Highest Point Possible: {config.heightmapMaxElevation} ft</div>
         </div>
       }
-      <div className={css.timeDisplay}>
-        {
-          simulation.isFireEventActive &&
-          <>
-            {timeInDays} {timeInDays === 1 ? "day" : "days"} and {timeHours} {timeHours === 1 ? "hour" : "hours"}
-          </>
-        }
-        {
-          !simulation.isFireEventActive &&
-          <>
-            {timeInYears} years
-          </>
-        }
-      </div>
       <div className={`${css.mainContent} ${ui.showChart && css.shrink}`}>
         <SimulationInfo />
         <View3d />

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -4,6 +4,7 @@ import { View3d } from "./view-3d/view-3d";
 import { SimulationInfo } from "./simulation-info";
 import { RightPanel } from "./right-panel";
 import { BottomBar } from "./bottom-bar";
+import { Timeline } from "./timeline/timeline";
 import { useStores } from "../use-stores";
 import { TopBar } from "./geohazard-components/top-bar/top-bar";
 import { AboutDialogContent } from "./about-dialog-content";
@@ -57,6 +58,9 @@ export const AppComponent = observer(function WrappedComponent() {
       <div className={`${css.mainContent} ${ui.showChart && css.shrink}`}>
         <SimulationInfo />
         <View3d />
+      </div>
+      <div className={css.timeline}>
+        <Timeline />
       </div>
       <div className={`${css.rightContent} ${ui.showChart && css.grow}`}>
         <RightPanel />

--- a/src/components/common.scss
+++ b/src/components/common.scss
@@ -1,6 +1,7 @@
 @import "./geohazard-components/common.scss";
 
-$scaleFont: 'Roboto Condensed', Lato, arial, sans-serif;
+$robotoCondensed: 'Roboto Condensed', Lato, arial, sans-serif;
+$lato: Lato, arial, sans-serif;
 
 $textColor: #434343;
 $controlIconLine: #797979;

--- a/src/components/right-panel.scss
+++ b/src/components/right-panel.scss
@@ -79,7 +79,7 @@
           width: 100%;
           height: 17px;
           margin: 10px auto;
-          font-family: Lato;
+          font-family: $lato;
           font-size: 14px;
           font-weight: bold;
           font-style: normal;

--- a/src/components/simulation-info.scss
+++ b/src/components/simulation-info.scss
@@ -10,89 +10,17 @@
   flex-wrap: nowrap;
   justify-content: center;
 
-  .zone {
-    display: flex;
-    margin: 10px;
-    margin-left: auto;
-    margin-right: auto;
-    width: 124px;
-    height: 34px;
-    border-radius: 4px;
-    padding: 6px 10px 4px 6px;
-    border: solid 1px $controlGray;
-    background-color: $zone1Red;
-    z-index: 2;
-    position: relative;
-
-    .lockIcon {
-      position: absolute;
-      right: -12px;
-      top: 4px;
-      width: 24px;
-      height: 24px;
+  @keyframes highlight {
+    0% {
+      background: #fff;
     }
-
-    &.active:hover {
-      box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.5);
-      cursor: pointer;
+    15% {
+      background: rgb(255, 158, 158);
     }
-
-    &.active:active {
-      box-shadow: 0 0 0 4px rgba(255, 255, 255, 1);
-    }
-
-    &.zone1 {
-      background-color: $zone1Red;
-    }
-    &.zone2 {
-      background-color: $zone2Blue;
-    }
-    &.zone3 {
-      background-color: $zone3Orange;
-    }
-    .icon {
-      width: 28px;
-      height: 28px;
-      padding-right: 8px;
-      display: inline-block;
-      &.droughtIcon {
-        width: 22px;
-        height: 20px;
-      }
-    }
-    .zoneText {
-      display: inline-block;
-      width: 58px;
-      height: 30px;
-      color: $controlText;
-
-      .zoneName {
-        font-family: Lato;
-        font-weight: bold;
-        font-size: 14px;
-        text-align: center;
-      }
-
-      .terrain {
-        font-family: 'Roboto Condensed';
-        font-size: 14px;
-        font-weight: normal;
-        text-align: center;
-      }
+    100% {
+      background: #fff;
     }
   }
-
-@keyframes highlight {
-  0% {
-    background: #fff;
-  }
-  15% {
-    background: rgb(255, 158, 158);
-  }
-  100% {
-    background: #fff;
-  }
-}
 
   .windContainer {
     width: 90px;
@@ -112,13 +40,13 @@
     }
 
     .windHeader {
-      font-family: Lato;
+      font-family: $lato;
       font-size: 12px;
       font-weight: bold;
       padding: 4px;
     }
     .windText {
-      font-family: 'Roboto Condensed';
+      font-family: $robotoCondensed;
       font-size: 11px;
       font-weight: normal;
       width: 60px;

--- a/src/components/timeline/timeline.scss
+++ b/src/components/timeline/timeline.scss
@@ -1,0 +1,88 @@
+@import "../common.scss";
+
+.timelineContainer {
+  width: 80%;
+  min-width: 500px;
+  height: 85px;
+  margin: 38px 86px 0 15.9px;
+  padding: 5px 10px 4px;
+  border-radius: 10px;
+  background-color: rgba(#fff, 0.5);
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  font-size: 14px;
+
+  .labels {
+    width: 95px;
+    height: 100%;
+    padding-right: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: space-around;
+
+    .labelBold {
+      font-family: $lato;
+      font-weight: bold;
+    }
+
+    .labelCondensed {
+      font-family: $robotoCondensed;
+    }
+  }
+
+  .graphs {
+    flex: 10;
+    flex-direction: column;
+    justify-content: space-around;
+    padding-right: 10px;
+
+    .vegetation {
+      height: 25px;
+    }
+
+    .time {
+      height: 31px;
+      position: relative;
+
+      .axis {
+        width: 100%;
+        height: 1px;
+        background-color: $textColor;
+      }
+
+      .progressBar {
+        background-color: #86e2ff;
+        height: 30px;
+        width: 100px;
+      }
+
+      .tickContainer {
+        position: absolute;
+        top: 0;
+        left: 10px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: center;
+        // It may seem strange, but content will overflow easily and it helps with centering the container perfectly.
+        width: 0px;
+
+        .tickSymbol {
+          width: 1px;
+          height: 6px;
+          background-color: $textColor;
+        }
+
+        .tickLabel {
+          font-family: $robotoCondensed;
+        }
+      }
+    }
+
+    .fireEvents {
+
+    }
+  }
+}

--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { clsx } from "clsx";
+import { observer } from "mobx-react";
+import { useStores } from "../../use-stores";
+
+import css from "./timeline.scss";
+
+
+const TICK_COUNT = 16;
+
+export const Timeline: React.FC = observer(function WrappedComponent() {
+  const { simulation } = useStores();
+
+  const tickDiff = simulation.config.simulationEndYear / TICK_COUNT;
+  const ticks = Array.from({ length: TICK_COUNT + 1 }, (_, i) => i * tickDiff);
+  const timeProgress = `${(simulation.timeInYears / simulation.config.simulationEndYear) * 100}%`;
+
+  return (
+    <div className={css.timelineContainer}>
+      <div className={css.labels}>
+        <div className={css.labelBold}>Vegetation (%)</div>
+        <div className={css.labelCondensed}>Time (years)</div>
+        <div className={css.labelBold}>Fire Events</div>
+      </div>
+      <div className={css.graphs}>
+        <div className={css.vegetation} />
+        <div className={css.time}>
+          <div className={css.axis} />
+          <div className={css.progressBar} style={{ width: timeProgress }} />
+          {
+            ticks.map((tick, i) => (
+              <div key={i} className={css.tickContainer} style={{ left: `${i * (100 / TICK_COUNT)}%` }}>
+                <div className={css.tickSymbol} />
+                <div className={css.tickLabel}>{ tick }</div>
+              </div>
+            ))
+          }
+        </div>
+        <div className={css.fireEvents} />
+      </div>
+    </div>
+  );
+});

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,9 @@
     <meta name="description" content="Forest Fire Simulation">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=yes">
     <link rel="shortcut icon" href="favicon.ico">
-    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Noto+Emoji:wght@700&family=Noto+Sans+Mono:wght@400;500&family=Noto+Sans+Symbols+2&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed" rel="stylesheet">
     <style>
       html, body, #app {


### PR DESCRIPTION
[[#185434214]](https://www.pivotaltracker.com/story/show/185434214)

This PR adds the timeline widget and time progress. It's implemented using HTML divs and CSS, as Michael was hoping we could make it responsive. It's already set to 80%, so it'll scale with the browser window. Using HTML/CSS seemed easy enough, and we don't have to deal with observing browser or container dimensions - most likely we'd need to do that if we used Canvas or SVG.