### PR TITLE
Add post-fire regrowth rules and expose probabilities in URL config

### DIFF
--- a/src/components/view-3d/terrain.tsx
+++ b/src/components/view-3d/terrain.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useLayoutEffect, useRef } from "react";
-import { Vegetation } from "../../types";
-import { BurnIndex, Cell, FireState } from "../../models/cell";
+import { Vegetation, BurnIndex, FireState } from "../../types";
+import { Cell } from "../../models/cell";
 import { ISimulationConfig } from "../../config";
 import * as THREE from "three";
 import { BufferAttribute } from "three";

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,21 @@ export interface ISimulationConfig {
   newWindDirection: number | undefined;
   // Works together with `changeWindOnDay`. Sets the new wind speed (mph). If undefined, it'll be random.
   newWindSpeed: number | undefined;
+  // Regrowth probabilities:
+  successionMinYears: number;
+  grassToShrub: number;
+  grassToShrubAdjacent: number;
+  shrubToDeciduous: number;
+  shrubToDeciduousAdjacent: number;
+  deciduousToConiferousMinYears: number;
+  deciduousToConiferous: number;
+  deciduousToConiferousAdjacent: number;
+  lowIntensityBurntAreaMinYears: number;
+  lowIntensityBurntShrubToGrass: number;
+  lowIntensityBurntDeciduousToGrass: number;
+  lowIntensityBurntConiferousToGrass: number;
+  highIntensityBurntAreaMinYears: number;
+  highIntensityBurntAreaToGrass: number;
 }
 
 export interface IUrlConfig extends ISimulationConfig {
@@ -165,7 +180,22 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   forestWithSuppressionAvailable: true,
   changeWindOnDay: undefined,
   newWindDirection: undefined,
-  newWindSpeed: undefined
+  newWindSpeed: undefined,
+  // Regrowth probabilities:
+  successionMinYears: 3,
+  grassToShrub: 0.1,
+  grassToShrubAdjacent: 0.3,
+  shrubToDeciduous: 0.1,
+  shrubToDeciduousAdjacent: 0.3,
+  deciduousToConiferousMinYears: 40,
+  deciduousToConiferous: 0.1,
+  deciduousToConiferousAdjacent: 0.3,
+  lowIntensityBurntAreaMinYears: 1,
+  lowIntensityBurntShrubToGrass: 0.4,
+  lowIntensityBurntDeciduousToGrass: 0.1,
+  lowIntensityBurntConiferousToGrass: 0.1,
+  highIntensityBurntAreaMinYears: 3,
+  highIntensityBurntAreaToGrass: 0.5
 });
 
 const getURLParam = (name: string) => {

--- a/src/models/cell.test.ts
+++ b/src/models/cell.test.ts
@@ -1,4 +1,5 @@
-import { BurnIndex, Cell } from "./cell";
+import { BurnIndex } from "../types";
+import { Cell } from "./cell";
 import { Zone } from "./zone";
 
 describe("Cell model", () => {

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -1,18 +1,5 @@
 import { Zone, moistureLookups } from "./zone";
-import { Vegetation, DroughtLevel, yearInMinutes } from "../types";
-
-export enum FireState {
-  Unburnt = 0,
-  Burning = 1,
-  Burnt = 2
-}
-
-// See: https://www.pivotaltracker.com/story/show/170344417
-export enum BurnIndex {
-  Low = 0,
-  Medium = 1,
-  High = 2
-}
+import { Vegetation, DroughtLevel, yearInMinutes, IBurnHistory, BurnIndex, FireState } from "../types";
 
 export interface CellOptions {
   x: number;
@@ -49,6 +36,7 @@ export class Cell {
   public isFireLineUnderConstruction = false;
   public helitackDropCount = 0;
   public fireIdx: number | null = null;
+  public burnsHistory: IBurnHistory[] = [];
   private _vegetation: Vegetation = Vegetation.Grass;
 
   constructor(props: CellOptions) {
@@ -123,6 +111,14 @@ export class Cell {
     return BurnIndex.High;
   }
 
+  public get lastFireBurnIndex() {
+    return this.burnsHistory[this.burnsHistory.length - 1]?.burnIndex;
+  }
+
+  public get lastFireTime() {
+    return this.burnsHistory[this.burnsHistory.length - 1]?.time;
+  }
+
   public get vegetationAgeInYears() {
     return this.vegetationAge / yearInMinutes;
   }
@@ -141,15 +137,20 @@ export class Cell {
     return !this.isNonburnable && (!this.isFireLine || burnIndex === BurnIndex.High);
   }
 
-  public reset() {
+  public preFireEventReset() {
     this.ignitionTime = Infinity;
     this.spreadRate = 0;
     this.burnTime = MAX_BURN_TIME;
+    this.isFireSurvivor = false;
+  }
+
+  public reset() {
+    this.preFireEventReset();
     this.fireState = FireState.Unburnt;
     this.isFireLineUnderConstruction = false;
     this.isFireLine = false;
     this.helitackDropCount = 0;
-    this.isFireSurvivor = false;
     this.vegetation = this.zone.vegetation;
+    this.burnsHistory = [];
   }
 }

--- a/src/models/fire-engine/fire-engine.test.ts
+++ b/src/models/fire-engine/fire-engine.test.ts
@@ -1,8 +1,8 @@
-import { BurnIndex, Cell, FireState } from "../cell";
+import { Cell } from "../cell";
 import { FireEngine, getGridCellNeighbors, nonburnableCellBetween } from "./fire-engine";
 import { Vector2 } from "three";
 import { Zone } from "../zone";
-import { Vegetation, dayInMinutes } from "../../types";
+import { Vegetation, dayInMinutes, FireState, BurnIndex } from "../../types";
 
 describe("nonburnableCellBetween", () => {
   it("returns true if there's any nonburnable cell between two points", () => {

--- a/src/models/fire-engine/fire-engine.ts
+++ b/src/models/fire-engine/fire-engine.ts
@@ -1,7 +1,7 @@
 import { Vector2 } from "three";
-import { BurnIndex, Cell, FireState } from "../cell";
+import { Cell } from "../cell";
 import { getFireSpreadRate } from "./get-fire-spread-rate";
-import { IWindProps, dayInMinutes } from "../../types";
+import { IWindProps, dayInMinutes, BurnIndex, FireState } from "../../types";
 import { dist, withinDist, getGridIndexForLocation, forEachPointBetween, directNeighbours, } from "../utils/grid-utils";
 
 const endOfLowIntensityFireProbability: {[key: number]: number} = {
@@ -109,6 +109,8 @@ export class FireEngine {
     this.minCellBurnTime = config.minCellBurnTime;
     this.neighborsDist = config.fireEngineNeighborsDist;
     this.fireSurvivalProbability = config.fireSurvivalProbability;
+
+    this.cells.forEach(cell => cell.preFireEventReset());
   }
 
   public setSparks(sparks: Vector2[]) {
@@ -186,6 +188,7 @@ export class FireEngine {
       const ignitionTime = cell.ignitionTime;
       if (cell.fireState === FireState.Burning && time - ignitionTime > cell.burnTime) {
         newFireStateData[i] = FireState.Burnt;
+        cell.burnsHistory.push({ time, burnIndex: cell.burnIndex });
         if (cell.canSurviveFire && Math.random() < this.fireSurvivalProbability) {
           cell.isFireSurvivor = true;
         }

--- a/src/models/fire-engine/get-fire-spread-rate.ts
+++ b/src/models/fire-engine/get-fire-spread-rate.ts
@@ -90,13 +90,6 @@ export const getDirectionFactor =
  *   https://docs.google.com/spreadsheets/d/1ov3JUz6hXdnXChbXTz20Fo_9YoWmGukJgCaIMJeRUb4/
  *   UPDATED version: https://drive.google.com/file/d/1ck0nwlawOtK-GjCV4qJ6ztMcxh3utbv-/view
  *
- * Still to do:
- *  * Calculate the slope between two cells
- *  * Scale the value given the angle between these two cells and the wind
- *  * Break up this function into several curried functions which will allow us to calculate
- *    the spread times between two cells as quickly as possible. (Fuel types and magnitude of
- *    the wind can be curried, angle and slope will be calculated per pair)
- *
  * @param sourceCell Grid cell that is currently BURNING
  * @param targetCell Adjacent grid cell that is currently UNBURNT
  * @param wind Wind properties, speed and direction

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -65,8 +65,8 @@ const presets: { [key: string]: Partial<ISimulationConfig> } = {
   default: {
     zonesCount: 2,
     zones: [
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.DeciduousForest, droughtLevel: DroughtLevel.MildDrought },
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.DeciduousForest, droughtLevel: DroughtLevel.MildDrought },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest, droughtLevel: DroughtLevel.MildDrought },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest, droughtLevel: DroughtLevel.MildDrought },
     ],
     towns: []
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,24 @@ export interface ISpark {
   locked: boolean;
 }
 
+export enum FireState {
+  Unburnt = 0,
+  Burning = 1,
+  Burnt = 2
+}
+
+// See: https://www.pivotaltracker.com/story/show/170344417
+export enum BurnIndex {
+  Low = 0,
+  Medium = 1,
+  High = 2
+}
+
+export interface IBurnHistory {
+  time: number;
+  burnIndex: BurnIndex;
+}
+
 export const dayInMinutes = 1440;
 export const yearInMinutes = 365 * dayInMinutes;
 


### PR DESCRIPTION
[[#185307092]](https://www.pivotaltracker.com/story/show/185307092)

This PR adds a second part of the regrowth engine - rules that define what happens to the burnt cells. Also, I've added many new URL params, so it's possible to experiment with these values without having to modify the code.

Implemente rules:
> LOW intensity fires will result in faster regrowth. Everything will turn black except unburnt islands.
Grass: 100% grows back in 1 year as grass.
Shrub: 60% grows back in 1 year as shrub, 40% grows back as grass.
D.Forest: 90% grows back in 1 year as D.Forest, 10% grows back as grass  
C.Forest: 90% grows back in 1 year as C.Forest, 10% grows back as grass
Medium and High intensity fires will result in a slower regrowth.
In every case of a high intensity fire, regrowth is GRASS and it takes 3 years to grow back. Then, the process of succession proceeds.
