### PR TITLE
Add "Show All Data" button to the right panel

### DIFF
--- a/src/components/right-panel.scss
+++ b/src/components/right-panel.scss
@@ -22,6 +22,11 @@ $padding: 4px;
     height: 100%;
   }
 
+  &.wide {
+    width: 70vw;
+    right: -70vw;
+  }
+
   &.open {
     right: 0;
   }
@@ -64,3 +69,23 @@ $padding: 4px;
     }
   }
 }
+
+.graphControls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  button.allDataBtn {
+    margin-top: 30px;
+    border: 1px solid $controlGray;
+    border-radius: 5px;
+    font-family: $lato;
+    font-size: 12px;
+    color: $controlText;
+    box-sizing: border-box;
+    width: 121px;
+    height: 29px;
+  }
+}
+
+

--- a/src/components/right-panel.tsx
+++ b/src/components/right-panel.tsx
@@ -1,13 +1,17 @@
 import { observer } from "mobx-react";
-import React from "react";
+import React, { useState } from "react";
+import { Button } from "@mui/material";
+import { clsx } from "clsx";
 import { VegetationGraph } from "./vegetation-graph";
 import { useStores } from "../use-stores";
 import { log } from "@concord-consortium/lara-interactive-api";
 
 import css from "./right-panel.scss";
 
+
 export const RightPanel = observer(() => {
-  const { ui } = useStores();
+  const { ui, simulation } = useStores();
+  const [allData, setAllData] = useState(false);
 
   const handleToggleDrawer = (e: React.SyntheticEvent) => {
     ui.toggleChart();
@@ -19,10 +23,23 @@ export const RightPanel = observer(() => {
     }
   };
 
+  const handleShowAllData = () => {
+    if (!allData) {
+      log("AllDataShown");
+    } else {
+      log("AllDataHidden");
+    }
+
+    setAllData(!allData);
+  };
+
   return (
-    <div className={`${css.rightPanel} ${ui.showChart ? css.open : ""}`} data-testid="right-panel">
+    <div className={clsx(css.rightPanel, {[css.open]: ui.showChart, [css.wide]: simulation.config.graphWideAllData && allData })}>
       <div className={css.rightPanelContent}>
-        <VegetationGraph allData={false} />
+        <VegetationGraph allData={allData} />
+        <div className={css.graphControls}>
+          <Button className={css.allDataBtn} onClick={handleShowAllData}>{allData ? "Show Recent Data": "Show All Data"}</Button>
+        </div>
       </div>
       <div className={css.rightPanelTabs}>
         <div className={css.rightPanelTab} onClick={handleToggleDrawer}>

--- a/src/components/vegetation-graph.tsx
+++ b/src/components/vegetation-graph.tsx
@@ -152,9 +152,17 @@ export const VegetationGraph: React.FC<IProps> = observer(({ allData }) => {
     ]
   };
 
+  const barPercentage = simulation.config.graphBarPercentage;
+  const wideAllData = simulation.config.graphWideAllData;
+  const options = {
+    ...defaultOptions,
+    // When all data graph is squeezed in the narrow right panel, set bar percentage to 1 to avoid aliasing artifacts.
+    barPercentage: allData ? (wideAllData ? barPercentage : 1) : barPercentage
+  };
+
   return (
     <div style={{height: "210px", width: "100%" }}>
-      <Bar options={defaultOptions} data={data} />
+      <Bar options={options} data={data} />
     </div>
   );
 });

--- a/src/components/vegetation-graph.tsx
+++ b/src/components/vegetation-graph.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { observer } from "mobx-react";
 import { useStores } from "../use-stores";
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, BarElement, Title, Tooltip, Filler, Legend, defaults } from "chart.js";
-import { Line, Bar } from "react-chartjs-2";
+import { Bar } from "react-chartjs-2";
 import { Vegetation } from "../types";
 
 import cssExports from "./common.scss";
@@ -15,6 +15,7 @@ ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarEleme
 
 export const defaultOptions = {
   responsive: true,
+  maintainAspectRatio: false,
   animation: {
     duration: 0,
   },
@@ -32,12 +33,12 @@ export const defaultOptions = {
       }
     },
   },
-  categoryPercentage: 1, // no spacing between bars
-  barPercentage: 0.9,
+  categoryPercentage: 1, // no additional spacing between bar categories
+  barPercentage: 0.85,
   scales: {
     x: {
       ticks: {
-        maxTicksLimit: 6,
+        maxTicksLimit: 7,
       },
       grid: {
         display: false
@@ -74,8 +75,7 @@ const datasetOptions = {
   borderWidth: 0,
 };
 
-const RECENT_YEARS = 26;
-const GRAPH_HEIGHT = 210;
+const RECENT_YEARS = 51;
 
 export interface IProps {
   allData?: boolean;
@@ -152,15 +152,9 @@ export const VegetationGraph: React.FC<IProps> = observer(({ allData }) => {
     ]
   };
 
-  const options = {
-    ...defaultOptions,
-    barPercentage: allData ? 1 : 0.9, // remove spacing between bars when displaying all data
-  };
-
   return (
-    <>
-      <Line options={options} data={data} height={GRAPH_HEIGHT} />
-      <Bar options={options} data={data} height={GRAPH_HEIGHT} />
-    </>
+    <div style={{height: "210px", width: "100%" }}>
+      <Bar options={defaultOptions} data={data} />
+    </div>
   );
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,10 @@ export interface ISimulationConfig {
   newWindDirection: number | undefined;
   // Works together with `changeWindOnDay`. Sets the new wind speed (mph). If undefined, it'll be random.
   newWindSpeed: number | undefined;
+  // Adjusts spacing between bars in the vegetation bar chart, [0, 1].
+  graphBarPercentage: number;
+  // When true, "Show All Data" will expand the right panel to 75% of the screen width.
+  graphWideAllData: boolean;
   // Regrowth probabilities:
   successionMinYears: number;
   grassToShrub: number;
@@ -181,6 +185,8 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   changeWindOnDay: undefined,
   newWindDirection: undefined,
   newWindSpeed: undefined,
+  graphBarPercentage: 0.85,
+  graphWideAllData: true,
   // Regrowth probabilities:
   successionMinYears: 3,
   grassToShrub: 0.1,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185510408

This PR adds "Show All Data" button below the graphs. It'll also make the right tab wider depending on the new URL param: `graphWideAllData`. Plus, there's a new option that sets bar percentage so Trudi or Micheal can find their fav value.