### PR TITLE
Simplify placing of the sparks

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -11,6 +11,7 @@ import { TopBar } from "./geohazard-components/top-bar/top-bar";
 import { AboutDialogContent } from "./about-dialog-content";
 import { ShareDialogContent } from "./share-dialog-content";
 import { useCustomCursor } from "./use-custom-cursors";
+import { mainContentId } from "../types";
 import Shutterbug from "shutterbug";
 
 import css from "./app.scss";
@@ -39,7 +40,7 @@ export const AppComponent = observer(function WrappedComponent() {
           <div>Highest Point Possible: {config.heightmapMaxElevation} ft</div>
         </div>
       }
-      <div className={clsx(css.mainContent, {[css.shrink]: ui.showChart})}>
+      <div id={mainContentId} className={clsx(css.mainContent, {[css.shrink]: ui.showChart})}>
         <SimulationInfo />
         <View3d />
       </div>

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { clsx } from "clsx";
 import { BottomBarContainer, BottomBarWidgetGroup } from "./geohazard-components/bottom-bar/bottom-bar-container";
 import { PlaybackControls } from "./geohazard-components/bottom-bar/playback-controls";
@@ -44,8 +44,13 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
   };
 
   const placeSpark = () => {
-    ui.interaction = Interaction.PlaceSpark;
-    log("SparkButtonClicked");
+    if (ui.interaction !== Interaction.PlaceSpark) {
+      ui.interaction = Interaction.PlaceSpark;
+      log("SparkInteractionActivated");
+    } else {
+      ui.interaction = null;
+      log("SparkInteractionCancelled");
+    }
   };
 
   const toggleFireEvent = () => {
@@ -58,7 +63,16 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
     }
   };
 
-  const sparkBtnDisabled = !simulation.isFireEventActive || !simulation.canAddSpark || ui.interaction === Interaction.PlaceSpark;
+  useEffect(() => {
+    if (!simulation.canAddSpark) {
+      ui.interaction = null;
+    }
+    if (!simulation.isFireEventActive) {
+      ui.interaction = null;
+    }
+  }, [simulation.canAddSpark, simulation.isFireEventActive, ui]);
+
+  const sparkBtnDisabled = !simulation.isFireEventActive || !simulation.canAddSpark;
   // Sparks counter should actually be "enabled" (fully visible) when there's no more sparks left to clearly show
   // why the button is disabled.
   const sparkCountDisabled = sparkBtnDisabled && simulation.remainingSparks > 0;
@@ -98,6 +112,7 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
           buttonText="Spark"
           dataTest="spark-button"
           onClick={placeSpark}
+          selected={ui.interaction === Interaction.PlaceSpark}
         />
       </BottomBarWidgetGroup>
       <PlaybackControls

--- a/src/components/use-custom-cursors.ts
+++ b/src/components/use-custom-cursors.ts
@@ -2,6 +2,7 @@ import { useStores } from "../use-stores";
 import sparkCursorImg from "../assets/interactions/spark-cursor.png";
 import { Interaction } from "../models/ui";
 import { useEffect } from "react";
+import { mainContentId } from "../types";
 
 const interactionCursors: {[key in Interaction]?: string} = {
   [Interaction.PlaceSpark]: `url(${sparkCursorImg}) 32 64, crosshair`,
@@ -12,14 +13,18 @@ export const useCustomCursor = () => {
   const { ui } = useStores();
 
   useEffect(() => {
+    const element = document.getElementById(mainContentId);
+    if (!element) {
+      return;
+    }
     if (ui.dragging) {
-      document.body.style.cursor = "move";
+      element.style.cursor = "move";
       return;
     }
     if (ui.interaction && interactionCursors[ui.interaction]) {
-      document.body.style.cursor = interactionCursors[ui.interaction] as string;
+      element.style.cursor = interactionCursors[ui.interaction] as string;
       return;
     }
-    document.body.style.cursor = "default";
+    element.style.cursor = "default";
   }, [ui.interaction, ui.dragging]);
 };

--- a/src/components/view-3d/terrain.tsx
+++ b/src/components/view-3d/terrain.tsx
@@ -31,9 +31,9 @@ const BURNING_COLOR = [1, 0, 0];
 const BURNT_COLOR = [0.2, 0.2, 0.2];
 const FIRE_LINE_UNDER_CONSTRUCTION_COLOR = [0.5, 0.5, 0];
 
-export const BURN_INDEX_LOW = [1, 0.7, 0];
-export const BURN_INDEX_MEDIUM = [1, 0.5, 0];
-export const BURN_INDEX_HIGH = [1, 0, 0];
+export const BURN_INDEX_LOW = [1, 0.9058823529, 0.4588235294];
+export const BURN_INDEX_MEDIUM = [1, 0.7568627451, 0.2509803922];
+export const BURN_INDEX_HIGH = [1, 0.3764705882, 0.3764705882];
 
 const burnIndexColor = (burnIndex: BurnIndex) => {
   if (burnIndex === BurnIndex.Low) {

--- a/src/components/view-3d/use-place-spark-interaction.tsx
+++ b/src/components/view-3d/use-place-spark-interaction.tsx
@@ -14,7 +14,6 @@ export const usePlaceSparkInteraction = () => {
       const y = e.point.y / ratio;
       simulation.addSpark(x, y);
       const cell = simulation.cellAt(x, y);
-      ui.interaction = null;
       log("SparkPlaced", { x: x / simulation.config.modelWidth, y: y / simulation.config.modelHeight, elevation: cell.elevation });
     }
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,7 +129,7 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   sparks: [],
   maxSparks: 10,
   fireEngineMaxTimeStep: 180, // minutes
-  fireEventDayInSeconds: 8, // one day in model should last X seconds in real world
+  fireEventDayInSeconds: 2, // one day in model should last X seconds in real world
   regrowthYearInSeconds: 60 / 240, // Complete simulation should take around 60 seconds.
   simulationEndYear: 240,
   windSpeed: 0, // mph

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,3 +94,4 @@ export type VegetationStatistics = Record<Vegetation | "burned", number>;
 export const dayInMinutes = 1440;
 export const yearInMinutes = 365 * dayInMinutes;
 
+export const mainContentId = "main-content";


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185542965

This PR simplifies placing sparks. Users no longer have to click the spark button each time they want a place a new spark. Now, this button is a toggle and lets users place multiple sparks at once.