### PR TITLE
Regrowth of vegetation in an area that has experienced multiple burns should be slower/less for conifers

### DIFF
--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -163,6 +163,22 @@ export class Cell {
     this.vegetationAge = 0;
   }
 
+  public isInMultipleBurnsState(time: number) {
+    // Check fire history if 2 or more files have occurred within 30 years window span.
+    const postMultipleBurnsStateLength = 150 * yearInMinutes; // 150 years after multiple burns within 30 years
+    const multipleBurnsWindow = 30 * yearInMinutes;
+
+    for (let i = this.fireHistory.length - 1; i >= 1; i--) {
+      const fire = this.fireHistory[i];
+      const prevFire = this.fireHistory[i - 1];
+      if (time - fire.time <= postMultipleBurnsStateLength && fire.time - prevFire.time <= multipleBurnsWindow) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   public accumulateCarbon(yearsDiff = 1) {
     this.storedCarbon += carbonAccumulationRate(this.vegetation) * yearsDiff;
     this.storedCarbon = Math.min(carbonMaxCapacity(this.vegetation), this.storedCarbon);

--- a/src/models/fire-engine/fire-engine.test.ts
+++ b/src/models/fire-engine/fire-engine.test.ts
@@ -75,7 +75,7 @@ describe("FireEngine", () => {
     engine.fires.forEach(fire => {
       expect(fire.endOfLowIntensityFire).toBe(false);
     });
-    engine.updateFire(dayInMinutes * 5); // 5 days in minutes
+    engine.updateFire(dayInMinutes * 5, dayInMinutes * 5); // 5 days in minutes
     engine.fires.forEach(fire => {
       expect(fire.endOfLowIntensityFire).toBe(true);
     });
@@ -84,11 +84,11 @@ describe("FireEngine", () => {
   it("should detect when nothing is burning anymore", () => {
     const engine = new FireEngine(generateCells(), wind, config);
     engine.setSparks(sparks);
-    engine.updateFire(dayInMinutes * 5);
+    engine.updateFire(dayInMinutes * 5, dayInMinutes * 5);
     expect(engine.fireDidStop).toBe(false);
     expect(engine.cells.filter(c => c.isBurningOrWillBurn).length).toBeGreaterThan(0);
-    engine.updateFire(dayInMinutes * 6);
-    engine.updateFire(dayInMinutes * 7);
+    engine.updateFire(dayInMinutes * 6, dayInMinutes * 6);
+    engine.updateFire(dayInMinutes * 7, dayInMinutes * 7);
     expect(engine.cells.filter(c => c.isBurningOrWillBurn).length).toEqual(0);
     expect(engine.fireDidStop).toBe(true);
   });
@@ -108,7 +108,7 @@ describe("FireEngine", () => {
     const engine = new FireEngine(cells, wind, config);
     engine.setSparks(sparks);
     engine.cells.forEach(c => expect(c.isUnburntIsland).toEqual(false));
-    engine.updateFire(dayInMinutes);
+    engine.updateFire(dayInMinutes, dayInMinutes);
     expect(engine.cells.filter(c => c.isBurningOrWillBurn).length).toBeGreaterThan(0);
   });
 
@@ -119,9 +119,9 @@ describe("FireEngine", () => {
       const engine = new FireEngine(generateCells(zone), wind, config);
       engine.setSparks(sparks);
       expect(engine.cells.filter(c => c.fireState === FireState.Survived).length).toEqual(0);
-      engine.updateFire(dayInMinutes);
-      engine.updateFire(dayInMinutes);
-      engine.updateFire(dayInMinutes);
+      engine.updateFire(dayInMinutes, dayInMinutes);
+      engine.updateFire(dayInMinutes, dayInMinutes);
+      engine.updateFire(dayInMinutes, dayInMinutes);
       return engine.cells.filter(c => c.fireState === FireState.Survived).length;
     };
 

--- a/src/models/fire-engine/fire-engine.ts
+++ b/src/models/fire-engine/fire-engine.ts
@@ -155,11 +155,11 @@ export class FireEngine {
     }
   }
 
-  public updateFire(time: number) {
-    this.time = time;
+  public updateFire(fireEventTime: number, time: number) {
+    this.time = fireEventTime;
 
     this.fires.forEach(fire => {
-      const fireDuration = time - fire.startTime;
+      const fireDuration = fireEventTime - fire.startTime;
       // Each time a day changes check if the low intensity fire shouldn't go out on itself.
       const newDay = Math.floor(fireDuration / dayInMinutes);
       if (newDay !== fire.day) {
@@ -186,14 +186,14 @@ export class FireEngine {
         this.fireDidStop = false; // fire still going on
       }
       const ignitionTime = cell.ignitionTime;
-      if (cell.fireState === FireState.Burning && time - ignitionTime > cell.burnTime) {
+      if (cell.fireState === FireState.Burning && fireEventTime - ignitionTime > cell.burnTime) {
         if (cell.canSurviveFire && Math.random() < this.fireSurvivalProbability) {
           newFireStateData[i] = FireState.Survived;
         } else {
           newFireStateData[i] = FireState.Burnt;
           cell.fireHistory.push({ time, burnIndex: cell.burnIndex });
         }
-      } else if (cell.fireState === FireState.Unburnt && time > ignitionTime ) {
+      } else if (cell.fireState === FireState.Unburnt && fireEventTime > ignitionTime ) {
         // Sets any unburnt cells to burning if we are passed their ignition time.
         // Although during a simulation all cells will have their state sent to BURNING through the process
         // above, this not only allows us to pre-set ignition times for testing, but will also allow us to

--- a/src/models/regrowth-engine/regrowth-engine.ts
+++ b/src/models/regrowth-engine/regrowth-engine.ts
@@ -104,7 +104,9 @@ export class RegrowthEngine {
           if (randomNumber < (adjacentDeciduousForest ? p.shrubToDeciduousAdjacent : p.shrubToDeciduous)) {
             cell.vegetation = Vegetation.DeciduousForest;
           }
-        } else if (cell.vegetation === Vegetation.DeciduousForest && cell.vegetationAgeInYears > p.deciduousToConiferousMinYears * droughtLevelFactor) {
+        } else if (cell.vegetation === Vegetation.DeciduousForest &&
+            !cell.isInMultipleBurnsState(time) && // When cell experienced multiple burns within short time span, coniferous trees will not grow.
+            cell.vegetationAgeInYears > p.deciduousToConiferousMinYears * droughtLevelFactor) {
           const adjacentConiferousForest = this.isAdjacentVegetationPresent(cell, Vegetation.ConiferousForest);
           if (randomNumber < (adjacentConiferousForest ? p.deciduousToConiferousAdjacent : p.deciduousToConiferous)) {
             cell.vegetation = Vegetation.ConiferousForest;

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -371,7 +371,7 @@ export class SimulationModel {
 
     if (this.fireEngine) {
       this.processSparks();
-      this.fireEngine.updateFire(this.fireEventTime);
+      this.fireEngine.updateFire(this.fireEventTime, this.time);
       this.updateCellsStateFlag();
       this.isFireActive = !this.fireEngine.fireDidStop;
       if (!this.isFireActive) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186598142

This PR introduces a new rule, as requested by the project team, that identifies occurrences of two or more fires within a 30-year window and suppresses the regrowth of conifers for 150 years in such cases.