### PR TITLE
Set drought to increase linearly throughout a model run, add climateChange URL param 

### DIFF
--- a/src/components/simulation-info.scss
+++ b/src/components/simulation-info.scss
@@ -43,6 +43,14 @@
     margin-top: 6px;
   }
 
+  .text {
+    font-family: $robotoCondensed;
+    font-size: 14px;
+    font-weight: normal;
+    font-stretch: condensed;
+    margin-bottom: 5px;
+  }
+
   .vegetationStats {
 
     .stat {
@@ -104,14 +112,6 @@
 
     .windDidChange {
       animation: highlight 2s ease-in-out;
-    }
-
-    .windText {
-      font-family: $robotoCondensed;
-      font-size: 14px;
-      font-weight: normal;
-      font-stretch: condensed;
-      margin-bottom: 5px;
     }
 
     .windDial {

--- a/src/components/simulation-info.tsx
+++ b/src/components/simulation-info.tsx
@@ -2,14 +2,19 @@ import React from "react";
 import { observer } from "mobx-react";
 import { useStores } from "../use-stores";
 import { WindDial, degToCompass } from "./wind-dial";
-import { Vegetation } from "../types";
+import { DroughtLevel, Vegetation } from "../types";
 import { clsx } from "clsx";
 
 import css from "./simulation-info.scss";
 
+const avgTempLabels = ["Low", "Normal", "High", "Very High", "Extreme"];
+
 export const SimulationInfo = observer(function WrappedComponent() {
   const { simulation } = useStores();
+  const showTempInfo = simulation.initialDroughtLevel !== simulation.finalDroughtLevel;
   const scaledWind = simulation.wind.speed / simulation.config.windScaleFactor;
+  const avgTemp = (simulation.droughtLevel / DroughtLevel.SevereDrought) * avgTempLabels.length;
+  const avgTempLabel = avgTempLabels[Math.min(avgTempLabels.length - 1, Math.floor(avgTemp))];
   const stats = simulation.vegetationStatistics;
 
   const getStat = (vegetation: Vegetation | "burned") => `${Math.round(stats[vegetation] * 100)}%`;
@@ -27,9 +32,19 @@ export const SimulationInfo = observer(function WrappedComponent() {
         <div className={css.stat}><div className={clsx(css.box, css.burned)}>{ getStat("burned") }</div> Burned</div>
       </div>
 
+      {
+        showTempInfo &&
+        <div className={css.container} >
+          <div className={css.header}>Average Temp.</div>
+          <div className={css.text}>
+            {`${avgTemp.toFixed(2)}: ${avgTempLabel}`}
+          </div>
+        </div>
+      }
+
       <div className={clsx(css.container, css.wind, { [css.windDidChange] : simulation.windDidChange })} >
         <div className={css.header}>Wind</div>
-        <div className={css.windText}>
+        <div className={css.text}>
             {`${Math.round(scaledWind)} MPH from ${degToCompass(simulation.wind.direction)}`}
         </div>
         <div className={css.windDial}>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,3 @@
-import { ZoneOptions } from "./models/zone";
 import { DroughtLevel, Vegetation, TerrainType, dayInMinutes } from "./types";
 
 import riverTexture from "./assets/data/river-texmap.png";
@@ -10,6 +9,11 @@ interface TownOptions {
   x: number; // [0, 1], position relative to model width
   y: number; // [0, 1], position relative to model height
   terrainType?: TerrainType; // limit town marker to given terrain type
+}
+
+interface ZoneConfig {
+  vegetation: Vegetation;
+  terrainType: TerrainType;
 }
 
 export interface ISimulationConfig {
@@ -55,7 +59,7 @@ export interface ISimulationConfig {
   heightmapMaxElevation: number; // ft
   // Number of zones that the model is using. Zones are used to keep properties of some area of the model.
   zonesCount?: 2 | 3;
-  zones: [ZoneOptions, ZoneOptions, ZoneOptions?];
+  zones: [ZoneConfig, ZoneConfig] | [ZoneConfig, ZoneConfig, ZoneConfig];
   towns: TownOptions[];
   // Visually fills edges of the terrain by setting elevation to 0.
   fillTerrainEdges: boolean;
@@ -85,10 +89,6 @@ export interface ISimulationConfig {
   // River color, RGBA values (range: [0, 1]). Suggested colors:
   // [0.663,0.855,1,1], [0.337,0.69,0.957,1] or [0.067,0.529,0.882,1]
   riverColor: [number, number, number, number];
-  // Authors may want to disable the fireline and helitack features completely
-  fireLineAvailable: boolean;
-  helitackAvailable: boolean;
-  forestWithSuppressionAvailable: boolean;
   // If set to a number, the wind direction and strength will change during the model run.
   changeWindOnDay: number | undefined;
   // Works together with `changeWindOnDay`. Sets the new wind direction (0 to 360). If undefined, it'll be random.
@@ -99,6 +99,8 @@ export interface ISimulationConfig {
   graphBarPercentage: number;
   // When true, "Show All Data" will expand the right panel to 75% of the screen width.
   graphWideAllData: boolean;
+  // Range of drought levels that change over time due to climate change.
+  climateChange: [number, number];
   // Regrowth probabilities:
   successionMinYears: number;
   grassToShrub: number;
@@ -155,18 +157,15 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   zones: [
     {
       terrainType: TerrainType.Plains,
-      vegetation: Vegetation.Grass,
-      droughtLevel: DroughtLevel.MildDrought
+      vegetation: Vegetation.Grass
     },
     {
       terrainType: TerrainType.Plains,
-      vegetation: Vegetation.Shrub,
-      droughtLevel: DroughtLevel.MediumDrought
+      vegetation: Vegetation.Shrub
     },
     {
       terrainType: TerrainType.Plains,
-      vegetation: Vegetation.DeciduousForest,
-      droughtLevel: DroughtLevel.SevereDrought
+      vegetation: Vegetation.DeciduousForest
     }
   ],
   towns: [],
@@ -186,14 +185,12 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   droughtIndexLocked: false,
   severeDroughtAvailable: true,
   riverColor: [0.067, 0.529, 0.882, 1],
-  fireLineAvailable: true,
-  helitackAvailable: true,
-  forestWithSuppressionAvailable: true,
   changeWindOnDay: undefined,
   newWindDirection: undefined,
   newWindSpeed: undefined,
   graphBarPercentage: 0.85,
   graphWideAllData: true,
+  climateChange: [DroughtLevel.MediumDrought, DroughtLevel.SevereDrought],
   // Regrowth probabilities:
   successionMinYears: 3,
   grassToShrub: 0.1,

--- a/src/models/fire-engine/fire-engine.test.ts
+++ b/src/models/fire-engine/fire-engine.test.ts
@@ -2,7 +2,7 @@ import { Cell } from "../cell";
 import { FireEngine, getGridCellNeighbors, nonburnableCellBetween } from "./fire-engine";
 import { Vector2 } from "three";
 import { Zone } from "../zone";
-import { Vegetation, dayInMinutes, FireState, BurnIndex } from "../../types";
+import { Vegetation, dayInMinutes, FireState, BurnIndex, TerrainType, DroughtLevel } from "../../types";
 
 describe("nonburnableCellBetween", () => {
   it("returns true if there's any nonburnable cell between two points", () => {
@@ -58,7 +58,11 @@ describe("FireEngine", () => {
   };
   const wind = { speed: 0, direction: 0 };
   const sparks = [new Vector2(50000, 50000)];
-  const defaultZone = new Zone({});
+  const defaultZone = new Zone({
+    vegetation: Vegetation.Grass,
+    terrainType: TerrainType.Foothills,
+    droughtLevel: DroughtLevel.MildDrought
+  });
   const generateCells = (zone = defaultZone) => {
     const res = [];
     for (let x = 0; x < config.gridWidth; x += 1) {
@@ -115,7 +119,7 @@ describe("FireEngine", () => {
 
   describe("fire survivors", () => {
     const testVegetationAndGetNumberOfFireSurvivors = (vegetation: Vegetation) => {
-      const zone = new Zone({ vegetation });
+      const zone = new Zone({ vegetation, terrainType: TerrainType.Foothills, droughtLevel: DroughtLevel.MildDrought });
       const engine = new FireEngine(generateCells(zone), wind, config);
       engine.setSparks(sparks);
       expect(engine.cells.filter(c => c.fireState === FireState.Survived).length).toEqual(0);

--- a/src/models/regrowth-engine/regrowth-engine.ts
+++ b/src/models/regrowth-engine/regrowth-engine.ts
@@ -1,15 +1,10 @@
 import { Cell } from "../cell";
-import { Vegetation, yearInMinutes, FireState, BurnIndex, DroughtLevel } from "../../types";
+import { Vegetation, yearInMinutes, FireState, BurnIndex } from "../../types";
 import { getGridIndexForLocation } from "../utils/grid-utils";
+import { interpolate } from "../utils/interpolate";
 
 
-const DroughtLevelToRegrowthMultiplier: Record<DroughtLevel, number> = {
-  [DroughtLevel.NoDrought]: 0.5,
-  [DroughtLevel.MildDrought]: 0.8,
-  [DroughtLevel.MediumDrought]: 1,
-  [DroughtLevel.SevereDrought]: 1.5,
-};
-
+const DroughtLevelToRegrowthMultiplier = [0.5, 0.8, 1, 1.5];
 export interface IRegrowthEngineConfig {
   gridWidth: number;
   gridHeight: number;
@@ -86,7 +81,7 @@ export class RegrowthEngine {
     for (let i = 0; i < numCells; i++) {
       const cell = this.cells[i];
       cell.vegetationAge += yearInMinutes;
-      const droughtLevelFactor = DroughtLevelToRegrowthMultiplier[cell.droughtLevel];
+      const droughtLevelFactor = interpolate(DroughtLevelToRegrowthMultiplier, cell.droughtLevel);
 
       const randomNumber = Math.random() * droughtLevelFactor;
 

--- a/src/models/utils/interpolate.ts
+++ b/src/models/utils/interpolate.ts
@@ -1,0 +1,16 @@
+export const interpolate = (array: number[], index: number): number => {
+  // If the index is an integer, no interpolation is needed.
+  if (Number.isInteger(index)) {
+    return array[index];
+  }
+
+  // Calculate the indices of the levels to interpolate between
+  const lowerIndex = Math.floor(index);
+  const upperIndex = Math.ceil(index);
+
+  // Linear interpolation formula: y = y0 + (y1 - y0) * (x - x0) / (x1 - x0)
+  // Where x is the index, and y0, y1 are the values at the lower and upper indices
+  const interpolatedVal = array[lowerIndex] + (array[upperIndex] - array[lowerIndex]) * (index - lowerIndex);
+
+  return interpolatedVal;
+};

--- a/src/models/zone.ts
+++ b/src/models/zone.ts
@@ -2,24 +2,15 @@ import { Vegetation, TerrainType, DroughtLevel } from "../types";
 import { observable, makeObservable } from "mobx";
 
 export interface ZoneOptions {
-  vegetation?: Vegetation;
-  terrainType?: TerrainType;
-  droughtLevel?: number;
+  vegetation: Vegetation;
+  terrainType: TerrainType;
+  droughtLevel: number;
 }
 
-// values for each level of vegetation: Grass, Shrub, Forest, ConiferousForest
-export const moistureLookups: {[key in DroughtLevel]: number[]} = {
-  [DroughtLevel.NoDrought]: [0.1275, 0.255, 0.17, 0.2125],
-  [DroughtLevel.MildDrought]: [0.09, 0.18, 0.12, 0.15],
-  [DroughtLevel.MediumDrought]: [0.0525, 0.105, 0.07, 0.0875],
-  [DroughtLevel.SevereDrought]: [0.015, 0.03, 0.02, 0.025],
-};
-
-
 export class Zone {
-  @observable public vegetation: Vegetation = Vegetation.Grass;
-  @observable public terrainType: TerrainType = TerrainType.Foothills;
-  @observable public droughtLevel: DroughtLevel = DroughtLevel.MildDrought;
+  @observable public vegetation: Vegetation;
+  @observable public terrainType: TerrainType;
+  @observable public droughtLevel: DroughtLevel;
 
   constructor(props?: ZoneOptions) {
     makeObservable(this);

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -65,32 +65,34 @@ const presets: { [key: string]: Partial<ISimulationConfig> } = {
   default: {
     zonesCount: 2,
     zones: [
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest, droughtLevel: DroughtLevel.MediumDrought },
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest, droughtLevel: DroughtLevel.MediumDrought },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest },
     ],
     towns: []
   },
   mildDrought: {
     zonesCount: 2,
+    climateChange: [DroughtLevel.MildDrought, DroughtLevel.SevereDrought],
     zones: [
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest, droughtLevel: DroughtLevel.MildDrought },
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest, droughtLevel: DroughtLevel.MildDrought },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest },
     ],
     towns: []
   },
   severeDrought: {
     zonesCount: 2,
+    climateChange: [DroughtLevel.SevereDrought, DroughtLevel.SevereDrought],
     zones: [
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest, droughtLevel: DroughtLevel.SevereDrought },
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest, droughtLevel: DroughtLevel.SevereDrought },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ConiferousForest },
     ],
     towns: []
   },
   grass: {
     zonesCount: 2,
     zones: [
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Grass, droughtLevel: DroughtLevel.MediumDrought },
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Grass, droughtLevel: DroughtLevel.MediumDrought },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Grass },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Grass },
     ],
     towns: []
   }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185307318
https://www.pivotaltracker.com/story/show/187047154

This PR implements the logic described in the first PT story: the drought level should linearly increase over the years due to climate change. It also adds a "climateChange" URL parameter that authors/project teams can use to control this behavior. Additionally, I've added temporal widgets that show the current average temperature, making it easier to see what's happening.