### PR TITLE
187737051 center terrain

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -17,6 +17,11 @@
     top: $topBarHeight;
     left: 0;
     transition: $rightPanelTransition;
+
+    > div:nth-child(2) {//override 3js default 100% width to center terrain with sim info div on left
+      width: calc(100% - 123px) !important;
+      left: 123px;
+    }
   }
 
   .rightContent {

--- a/src/components/timeline/timeline.scss
+++ b/src/components/timeline/timeline.scss
@@ -11,6 +11,8 @@
   align-content: center;
   justify-content: center;
   font-size: 14px;
+  position: relative;
+  left: 63px;
 
   .labels {
     width: 95px;


### PR DESCRIPTION
Terrain was getting pushed to the left under the simulation info controls specially when graph panel is opened. This centers the terrain and the timeline container when the graph panel is open.