### PR TITLE
187832485 serialize temp

### DIFF
--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -417,8 +417,10 @@ export class SimulationModel {
       this.isFireActive = !this.fireEngine.fireDidStop;
       if (!this.isFireActive) {
         this.fireEngine = null;
-        // Fire event just ended. Remove all the spark markers.
+        // Fire event just ended. Remove all the spark markers. Reset Wind and Fire Danger to default values.
         this.sparks.length = 0;
+        this.setWindDirection(this.config.windDirection);
+        this.setWindSpeed(this.config.windSpeed);
       }
     }
 

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -23,6 +23,7 @@ export type Event = "yearChange" | "restart" | "start";
 
 export interface ISimulationSnapshot {
   time: number;
+  droughtLevel: number;
   cellSnapshots: ICellSnapshot[];
 }
 
@@ -500,12 +501,14 @@ export class SimulationModel {
   public snapshot(): ISimulationSnapshot {
     return {
       time: this.time,
+      droughtLevel: this.droughtLevel,
       cellSnapshots: this.cells.map(c => c.snapshot())
     };
   }
 
   public restoreSnapshot(snapshot: ISimulationSnapshot) {
     this.time = snapshot.time;
+    this.setDroughtLevel(snapshot.droughtLevel);
     snapshot.cellSnapshots.forEach((cellSnapshot, idx) => {
       this.cells[idx].restoreSnapshot(cellSnapshot);
     });


### PR DESCRIPTION
This saves and restores the drought level so that temp meter shows correct value on scrub.
This sets wind direction, wind speed, and fire danger to default values after a fire event has ended. Note that this PR does not restore the fire event yet, and so fire event wind direction, wind speed, and fire danger are not restored on scrub back.