### PR TITLE
Fix some issues related to serialization

### DIFF
--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -21,6 +21,7 @@ export const Timeline: React.FC = observer(function WrappedComponent() {
   const tickDiff = simulation.config.simulationEndYear / TICK_COUNT;
   const ticks = Array.from({ length: TICK_COUNT + 1 }, (_, i) => i * tickDiff);
   const marks = ticks.map((tick) => ({ value: tick, label: tick }));
+
   useEffect(() => {
     setDisabled(!simulation.simulationStarted || (simulation.simulationRunning && !simulation.simulationEnded));
   }, [simulation.simulationStarted, simulation.simulationRunning, simulation.simulationEnded]);
@@ -61,7 +62,6 @@ export const Timeline: React.FC = observer(function WrappedComponent() {
           minDiff = diff;
           closestSnapshotYear = snapshotYear;
         }
-      // }
     });
     return closestSnapshotYear;
   };

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -69,12 +69,10 @@ export interface CellOptions {
 }
 
 export interface ICellSnapshot {
-  zone: Zone;
-  zoneIdx?: number;
   fireIdx: number | null;
   fireHistory: IFireHistory[];
   fireState: FireState;
-  vegetation: Vegetation;
+  _vegetation: Vegetation;
 }
 
 const FIRE_LINE_DEPTH = 2000;
@@ -99,7 +97,7 @@ export class Cell {
   public helitackDropCount = 0;
   public fireIdx: number | null = null;
   public fireHistory: IFireHistory[] = [];
-  private _vegetation: Vegetation = Vegetation.Grass;
+  public _vegetation: Vegetation = Vegetation.Grass;
 
   constructor(props: CellOptions) {
     Object.assign(this, props);
@@ -256,12 +254,10 @@ export class Cell {
 
   public snapshot(): ICellSnapshot {
     return {
-      zone: this.zone,
-      zoneIdx: this.zoneIdx,
       fireIdx: this.fireIdx,
       fireHistory: [...this.fireHistory],
       fireState: this.fireState,
-      vegetation: this.vegetation,
+      _vegetation: this._vegetation,
     };
   }
 

--- a/src/models/snapshot-manager.test.ts
+++ b/src/models/snapshot-manager.test.ts
@@ -1,4 +1,4 @@
-import { SnapshotsManager } from "./snapshots-manager";
+import { SNAPSHOT_INTERVAL, SnapshotsManager } from "./snapshots-manager";
 import { SimulationModel } from "./simulation";
 
 const getSimpleSimulation = async () => {
@@ -28,17 +28,17 @@ describe("SnapshotsManager", () => {
   it("should create a snapshot on year change", async () => {
     const simulation = await getSimpleSimulation();
     const snapshotsManager = new SnapshotsManager(simulation);
-    while (simulation.timeInYears < 2) {
+    while (simulation.timeInYears < SNAPSHOT_INTERVAL) {
       simulation.tick(timeStep);
     }
 
-    expect(Math.floor(snapshotsManager.maxYear)).toBe(2);
+    expect(Math.floor(snapshotsManager.maxYear)).toBe(SNAPSHOT_INTERVAL);
     expect(snapshotsManager.snapshots).toHaveLength(1);
-    while (simulation.timeInYears < 5) {
+    while (simulation.timeInYears < 3 * SNAPSHOT_INTERVAL) {
       simulation.tick(timeStep);
     }
 
-    expect(Math.floor(snapshotsManager.maxYear)).toBe(5);
-    expect(snapshotsManager.snapshots).toHaveLength(4);
+    expect(Math.floor(snapshotsManager.maxYear)).toBe(3 * SNAPSHOT_INTERVAL);
+    expect(snapshotsManager.snapshots).toHaveLength(3);
   });
 });


### PR DESCRIPTION
This PR addresses a few issues I have identified so far. @eireland, I'll use your single-snapshot-type-exp branch as a base branch for PRs, and when things are reviewed and working, I'll simply merge it into master.

1. Temperature restoration was broken because `this.setClimateChangeEnabled(snapshot.climateChangeEnabled);` was called, which zeroes the temperature. We don't need to serialize the climate change switch value, as it cannot be changed during the simulation.
2. I've simplified and fixed how we skip unnecessary snapshots. When vegetation stats are the same, I reuse the existing `cellSnapshot` but still serialize other properties (like droughtLevel and temperature) since they might change. That was probably a second reason why the temperature was not restored correctly. They are also cheap to serialize. This approach ensures we never have to deal with `undefined` snapshots, making snapshot restoration simpler.
3. Related issue - incorrect vegetation stats were compared when checking if we could optimize the snapshot.
4. Now, I am serializing and restoring `_vegetation` without calling `setVegetation`, as that method also resets vegetation age, which would change/break simulation progress.