### PR TITLE
Simplify and update logic related to serialization

### DIFF
--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -108,9 +108,9 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
           dataTest="fire-event-button"
           onClick={toggleFireEvent}
           selected={simulation.isFireEventActive}
-           // user cannot cancel active fire or when user has scrubbed timeline back
+          // user cannot cancel active fire or when user has scrubbed timeline back
           disabled={simulation.isFireActive || simulation.simulationEnded
-                      || (!simulation.simulationRunning && (simulation.timeInYears < snapshotsManager.maxYear))}
+            || (!simulation.simulationRunning && snapshotsManager.pastStateLoaded)}
         />
         <div className={clsx(css.sparksCount, { [css.disabled]: sparkCountDisabled })}>{ simulation.remainingSparks }</div>
         <IconButton

--- a/src/components/simulation-info.tsx
+++ b/src/components/simulation-info.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import { clsx } from "clsx";
 import { useStores } from "../use-stores";
 import { WindDial, degToCompass } from "./wind-dial";
-import { Vegetation } from "../types";
+import { DroughtLevel, Vegetation } from "../types";
 import { Thermometer } from "./thermometer";
 import { FireDanger } from "./fire-danger";
 
@@ -14,6 +14,10 @@ export const SimulationInfo = observer(function WrappedComponent() {
   const scaledWind = simulation.wind.speed / simulation.config.windScaleFactor;
   const stats = simulation.vegetationStatistics;
   const fireEventActive = simulation.isFireEventActive;
+
+  // When fire event is not active, we should return the initial drought level. Fire Danger is inactive and the arrow
+  // should point the lowest value.
+  const fireDangerDroughtLevel = simulation.isFireEventActive ? simulation.droughtLevel : DroughtLevel.NoDrought;
 
   const getStat = (vegetation: Vegetation | "burned") => `${Math.round(stats[vegetation] * 100)}%`;
 
@@ -40,7 +44,7 @@ export const SimulationInfo = observer(function WrappedComponent() {
 
       <div className={clsx(css.container, { [css.inactive]: !fireEventActive })} >
         <div className={css.header}>Fire Danger</div>
-        <FireDanger droughtLevel={simulation.droughtLevel} scaledWindSpeed={scaledWind} />
+        <FireDanger droughtLevel={fireDangerDroughtLevel} scaledWindSpeed={scaledWind} />
       </div>
 
       <div className={clsx(css.container, css.wind, { [css.windDidChange] : simulation.windDidChange, [css.inactive]: !fireEventActive })} >

--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -15,11 +15,12 @@ export const Timeline: React.FC = observer(function WrappedComponent() {
   const { simulation, snapshotsManager } = useStores();
   const timeoutId = useRef(0);
   const [val, setVal] = useState(simulation.timeInYears);
-  const [timeProgress, setTimeProgress] = useState("0%");
 
   const tickDiff = simulation.config.simulationEndYear / TICK_COUNT;
   const ticks = Array.from({ length: TICK_COUNT + 1 }, (_, i) => i * tickDiff);
   const marks = ticks.map((tick) => ({ value: tick, label: tick }));
+
+  const timeProgress = `${snapshotsManager.maxYear / simulation.config.simulationEndYear * 100}%`;
 
   // disable the slider when the simulation is running, or when a fire event is active. It'd be possible to support
   // scrubbing the timeline while a fire event is active, but it would require some additional logic to handle the
@@ -28,19 +29,10 @@ export const Timeline: React.FC = observer(function WrappedComponent() {
     || (simulation.simulationRunning && !simulation.simulationEnded)
     || simulation.isFireEventActive;
 
-  // This useEffect is to update the timeline scrubber when the simulation is running
-  // progress bar and regrowth of vegetation
   useLayoutEffect(() => {
-    if (simulation.simulationRunning) {
-      if (snapshotsManager.maxYear > val) {
-        setVal(snapshotsManager.maxYear);
-        setTimeProgress(`${snapshotsManager.maxYear / simulation.config.simulationEndYear * 100}%`);
-      }
-    } else if (!simulation.simulationStarted) { // if the simulation is reloaded, reset the timeline
-      setVal(0);
-      setTimeProgress("0%");
-    }
-  }, [simulation.simulationStarted, simulation.simulationRunning, snapshotsManager.maxYear, simulation.timeInYears, simulation, val]);
+    // Update handle when simulation is updated.
+    setVal(simulation.timeInYears);
+  }, [simulation.timeInYears, simulation]);
 
   const handleSliderChange = (e: Event, value: number) => {
     if (simulation.simulationRunning) {

--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -4,12 +4,12 @@ import { useStores } from "../../use-stores";
 import { VegetationStats } from "./vegetation-stats";
 import { FireEvents } from "./fire-events";
 import { Slider } from "@mui/material";
+import { yearInMinutes } from "../../types";
 
 import css from "./timeline.scss";
-import { SNAPSHOT_INTERVAL } from "../../models/snapshots-manager";
 
 const TICK_COUNT = 16;
-const LOADING_DELAY = 100; // ms
+const LOADING_DELAY = 50; // ms
 
 export const Timeline: React.FC = observer(function WrappedComponent() {
   const { simulation, snapshotsManager } = useStores();
@@ -28,55 +28,33 @@ export const Timeline: React.FC = observer(function WrappedComponent() {
     || (simulation.simulationRunning && !simulation.simulationEnded)
     || simulation.isFireEventActive;
 
-  // if user has scrubbed back on the timeline, and then starts the sim again
-  // we need to restore the last snapshot and move the timeline scrubber to the max year
-  useLayoutEffect(() => {
-    if (simulation.simulationRunning && snapshotsManager.maxYear > val) {
-      snapshotsManager.restoreLastSnapshot();
-      simulation.start(); //when we restoreLastSnapshot, we need to start the simulation again
-    }
-  },[simulation, simulation.simulationRunning, snapshotsManager, val]);
-
   // This useEffect is to update the timeline scrubber when the simulation is running
   // progress bar and regrowth of vegetation
   useLayoutEffect(() => {
     if (simulation.simulationRunning) {
       if (snapshotsManager.maxYear > val) {
         setVal(snapshotsManager.maxYear);
-        simulation.setTimeInYears(snapshotsManager.maxYear);
         setTimeProgress(`${snapshotsManager.maxYear / simulation.config.simulationEndYear * 100}%`);
       }
     } else if (!simulation.simulationStarted) { // if the simulation is reloaded, reset the timeline
-      setTimeProgress("0%");
       setVal(0);
-      simulation.setTimeInYears(0);
+      setTimeProgress("0%");
     }
   }, [simulation.simulationStarted, simulation.simulationRunning, snapshotsManager.maxYear, simulation.timeInYears, simulation, val]);
 
-  const findClosestSnapshotYear = (value: number) => {
-    let closestSnapshotYear = 0;
-    let minDiff = Infinity;
-    snapshotsManager.snapshots.forEach((snapshot, index) => {
-      const snapshotYear = index * SNAPSHOT_INTERVAL;
-      // if (snapshot.simulationSnapshot !== undefined) {
-        const diff = Math.abs(snapshotYear - value);
-        if (diff < minDiff) {
-          minDiff = diff;
-          closestSnapshotYear = snapshotYear;
-        }
-    });
-    return closestSnapshotYear;
-  };
-
   const handleSliderChange = (e: Event, value: number) => {
-    if (!simulation.simulationRunning) {
-      value = findClosestSnapshotYear(value);
+    if (simulation.simulationRunning) {
+      return;
     }
     value = Math.min(snapshotsManager.maxYear, value);
-    setVal(value);
+    const closestSnapshot = snapshotsManager.findClosestSnapshot(value);
+    if (!closestSnapshot) {
+      return;
+    }
+    setVal(closestSnapshot.simulationSnapshot.time / yearInMinutes); // update the scrubber position
     window.clearTimeout(timeoutId.current);
     timeoutId.current = window.setTimeout(() => {
-      snapshotsManager.restoreSnapshot(value);
+      snapshotsManager.restoreSnapshot(closestSnapshot);
     }, LOADING_DELAY);
   };
 
@@ -101,7 +79,7 @@ export const Timeline: React.FC = observer(function WrappedComponent() {
                 thumb: disabled ? css.sliderThumbDisabled : css.sliderThumb,
               }}
               size="medium"
-              step={1}
+              step={0.01}
               min={0}
               max={simulation.config.simulationEndYear}
               value={val}

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -149,11 +149,6 @@ export class SimulationModel {
   }
 
   public get droughtLevel() {
-    // When fire event is not active, we should return the initial drought level. Fire Danger is inactive and
-    // the arrow should point the lowest value.
-    if (!this.isFireEventActive) {
-      return DroughtLevel.NoDrought;
-    }
     // average drought level of all zones
     return this.zones.reduce((sum, zone) => sum + zone.droughtLevel, 0) / this.zones.length;
   }

--- a/src/models/snapshot-manager.test.ts
+++ b/src/models/snapshot-manager.test.ts
@@ -1,5 +1,6 @@
 import { SNAPSHOT_INTERVAL, SnapshotsManager } from "./snapshots-manager";
 import { SimulationModel } from "./simulation";
+import { yearInMinutes } from "../types";
 
 const getSimpleSimulation = async () => {
   const s = new SimulationModel({
@@ -40,5 +41,35 @@ describe("SnapshotsManager", () => {
 
     expect(Math.floor(snapshotsManager.maxYear)).toBe(3 * SNAPSHOT_INTERVAL);
     expect(snapshotsManager.snapshots).toHaveLength(3);
+  });
+
+  describe("findClosestSnapshot", () => {
+    it("should return the closest snapshot", async () => {
+      const simulation = await getSimpleSimulation();
+      const snapshotsManager = new SnapshotsManager(simulation);
+      snapshotsManager.snapshots = [
+        { simulationSnapshot: { time: yearInMinutes * 0 } as any },
+        { simulationSnapshot: { time: yearInMinutes * 1 } as any },
+        { simulationSnapshot: { time: yearInMinutes * 1.2 } as any },
+        { simulationSnapshot: { time: yearInMinutes * 1.8 } as any },
+        { simulationSnapshot: { time: yearInMinutes * 2 } as any },
+      ];
+
+      expect(snapshotsManager.findClosestSnapshot(0)?.simulationSnapshot.time).toBeCloseTo(0 * yearInMinutes);
+      expect(snapshotsManager.findClosestSnapshot(1)?.simulationSnapshot.time).toBeCloseTo(1 * yearInMinutes);
+      expect(snapshotsManager.findClosestSnapshot(1.1)?.simulationSnapshot.time).toBeCloseTo(1.2 * yearInMinutes);
+      expect(snapshotsManager.findClosestSnapshot(1.2)?.simulationSnapshot.time).toBeCloseTo(1.2 * yearInMinutes);
+      expect(snapshotsManager.findClosestSnapshot(1.3)?.simulationSnapshot.time).toBeCloseTo(1.2 * yearInMinutes);
+      expect(snapshotsManager.findClosestSnapshot(1.51)?.simulationSnapshot.time).toBeCloseTo(1.8 * yearInMinutes);
+      expect(snapshotsManager.findClosestSnapshot(2)?.simulationSnapshot.time).toBeCloseTo(2 * yearInMinutes);
+      expect(snapshotsManager.findClosestSnapshot(5)?.simulationSnapshot.time).toBeCloseTo(2 * yearInMinutes);
+    });
+
+    it("should return null if no snapshots are available", async () => {
+      const simulation = await getSimpleSimulation();
+      const snapshotsManager = new SnapshotsManager(simulation);
+      const closestSnapshot = snapshotsManager.findClosestSnapshot(2.5);
+      expect(closestSnapshot).toBeNull();
+    });
   });
 });

--- a/src/models/snapshots-manager.ts
+++ b/src/models/snapshots-manager.ts
@@ -30,7 +30,7 @@ export class SnapshotsManager {
     this.reset();
   }
 
-  get lastSnapshot() {
+  get lastSnapshot(): ISnapshot | null {
     return this.snapshots[this.snapshots.length - 1] ?? null;
   }
 
@@ -46,36 +46,69 @@ export class SnapshotsManager {
     return this.lastSnapshotTime !== null && this.simulation.time < this.lastSnapshotTime;
   }
 
-  saveSnapshot(existingCellSnapshots?: ISimulationSnapshot["cellSnapshots"]) {
+  public tooCloseToLastSnapshot(year: number) {
+    return this.lastSnapshotYear !== null && Math.abs(year - this.lastSnapshotYear) < MIN_DISTANCE_TO_FIRE_EVENT;
+  }
+
+  public isFireEventSnapshot(snapshot: ISnapshot | null): boolean {
+    return !!snapshot && snapshot.simulationSnapshot.sparks.length > 0;
+  }
+
+  public findClosestSnapshot(year: number): ISnapshot | null {
+    let minDiff = Infinity;
+    let closestSnapshot: ISnapshot | null = null;
+    for (const snapshot of this.snapshots) {
+      const snapshotYear = snapshot.simulationSnapshot.time / yearInMinutes;
+      const diff = Math.abs(year - snapshotYear);
+      if (diff <= minDiff) {
+        minDiff = diff;
+        closestSnapshot = snapshot;
+      }
+    }
+    return closestSnapshot;
+  }
+
+  public saveSnapshot(existingCellSnapshots?: ISimulationSnapshot["cellSnapshots"]) {
     const snapshot = this.simulation.snapshot(existingCellSnapshots);
     this.snapshots.push({ simulationSnapshot: snapshot });
   }
 
-  tooCloseToLastSnapshot(year: number) {
-    return this.lastSnapshotYear !== null && Math.abs(year - this.lastSnapshotYear) < MIN_DISTANCE_TO_FIRE_EVENT;
+  public restoreSnapshot(snapshot: ISnapshot) {
+    this.simulation.restoreSnapshot(snapshot.simulationSnapshot);
+    this.simulation.updateCellsStateFlag();
   }
 
-  isFireEventSnapshot(snapshot: ISnapshot) {
-    return snapshot.simulationSnapshot.sparks.length > 0;
+  @action.bound public reset() {
+    this.snapshots = [];
+    this.maxYear = 0;
   }
 
-  @action.bound public onFireEventEnded() {
-    if (!this.isFireEventSnapshot(this.lastSnapshot) && this.tooCloseToLastSnapshot(this.simulation.timeInYears)) {
-      // Remove previous regular snapshot if it's too close to the fire event snapshot. This will help users to
-      // snap to the fire event snapshot when scrubbing the timeline.
-      this.snapshots.pop();
-    }
-    this.saveSnapshot();
-  }
+  // Simulation event handlers:
 
   @action.bound public onStart() {
     this.maxYear = 0;
+    // Skip snapshot handling when a fire event is active. A snapshot will be taken at the end of the fire event.
+    if (this.simulation.isFireEventActive) {
+      return;
+    }
     if (this.snapshots.length === 0) {
       this.saveSnapshot();
     }
   }
 
+  @action.bound public onStop() {
+    // Skip snapshot handling when a fire event is active. A snapshot will be taken at the end of the fire event.
+    if (this.simulation.isFireEventActive) {
+      return;
+    }
+    this.saveSnapshot();
+  }
+
   @action.bound public onResume() {
+    // Skip snapshot handling when a fire event is active. A snapshot will be taken at the end of the fire event.
+    if (this.simulation.isFireEventActive) {
+      return;
+    }
     if (this.lastSnapshot && this.lastSnapshot.simulationSnapshot.time !== this.simulation.time) {
       this.restoreSnapshot(this.lastSnapshot);
     }
@@ -83,11 +116,11 @@ export class SnapshotsManager {
     this.snapshots.pop();
   }
 
-  @action.bound public onStop() {
-    this.saveSnapshot();
-  }
-
   @action.bound public onYearChange() {
+    // Skip snapshot handling when a fire event is active. A snapshot will be taken at the end of the fire event.
+    if (this.simulation.isFireEventActive) {
+      return;
+    }
     if (this.simulation.timeInYears > this.maxYear) {
       this.maxYear = this.simulation.timeInYears;
     }
@@ -111,27 +144,12 @@ export class SnapshotsManager {
     }
   }
 
-  public findClosestSnapshot(year: number): ISnapshot | null {
-    let minDiff = Infinity;
-    let closestSnapshot: ISnapshot | null = null;
-    for (const snapshot of this.snapshots) {
-      const snapshotYear = snapshot.simulationSnapshot.time / yearInMinutes;
-      const diff = Math.abs(year - snapshotYear);
-      if (diff <= minDiff) {
-        minDiff = diff;
-        closestSnapshot = snapshot;
-      }
+  @action.bound public onFireEventEnded() {
+    if (!this.isFireEventSnapshot(this.lastSnapshot) && this.tooCloseToLastSnapshot(this.simulation.timeInYears)) {
+      // Remove previous regular snapshot if it's too close to the fire event snapshot. This will help users to
+      // snap to the fire event snapshot when scrubbing the timeline.
+      this.snapshots.pop();
     }
-    return closestSnapshot;
-  }
-
-  public restoreSnapshot(snapshot: ISnapshot) {
-    this.simulation.restoreSnapshot(snapshot.simulationSnapshot);
-    this.simulation.updateCellsStateFlag();
-  }
-
-  @action.bound public reset() {
-    this.snapshots = [];
-    this.maxYear = 0;
+    this.saveSnapshot();
   }
 }


### PR DESCRIPTION
This PR makes several adjustments to the serialization logic.

The biggest change is reducing the number of handled events. We don’t need to worry about `fireEventAdded` or `sparkAdded` anymore since the snapshot is taken at the end of the fire event. @eireland, you were probably seeing zero sparks because you were emitting this event after the sparks array was cleared. I’ve moved the event emitter line up a few lines to fix this.

The timeline now snaps to snapshots only instead of always jumping one year. This change helps with orientation (you won't experience moving the handle without any effect) and makes finding fire event snapshots easier.

I’ve also removed some `Math.floor` that were scattered around when dealing with year value. This ensures the handle's position aligns better with the fire event position.

Additionally, there are changes related to how snapshots are saved and restored. Some logic has been moved out of the Timeline's `useEffect` to the snapshot manager.

Lastly, I added a 2 year margin between fire event snapshots and regular snapshots, making them easier to locate.